### PR TITLE
Added missing magical item rarity

### DIFF
--- a/app/models/magic_item.rb
+++ b/app/models/magic_item.rb
@@ -3,5 +3,5 @@ class MagicItem < ActiveRecord::Base
   belongs_to :trade_log_entry
   belongs_to :character
 
-  enum rarity: [:common, :uncommon, :rare, :very_rare, :legendary, :unique]
+  enum rarity: [:common, :uncommon, :rare, :very_rare, :legendary, :wonderous, :unique]
 end


### PR DESCRIPTION
Was playing last week and I obtained Goggles of the Night which were classified as a wonderous magical item.