### PR TITLE
Fix DM log notes span

### DIFF
--- a/app/views/dm_log_entries/index.erb
+++ b/app/views/dm_log_entries/index.erb
@@ -118,7 +118,7 @@
         </tr>
         <% unless log_entry.notes.empty? %>
           <tr>
-            <td colspan='9'>
+            <td colspan='11'>
               <strong>Notes:</strong>
               <%= log_entry.notes %>
             </td>


### PR DESCRIPTION
## Description

Allows DM Log notes to span the full table width.

## Changes for review

* Update `colspan` for DM log entry notes

## Other notes

* These changes are related to this issue: Ariel-Thomas/adventurers-league-log#137