### PR TITLE
Fixes adventure name

### DIFF
--- a/lib/tasks/adventure_catalog.rake
+++ b/lib/tasks/adventure_catalog.rake
@@ -42,6 +42,8 @@ namespace :adventure_catalog do
         if row.length == 4
           if row[2].include? 'Lost Tales of Myth Drannor'
             row = [" DDAL00-02*", "1-4, 5-10, 11-16, 17-20", "12", "Lost Tales of Myth Drannor"]
+          elsif row[3].include? 'The Courtingof Fire'
+            row = [" DDEX1-5", "1-4", "4", "The Courting of Fire"]
           end
         end
 

--- a/lib/tasks/adventure_catalog.rake
+++ b/lib/tasks/adventure_catalog.rake
@@ -129,4 +129,10 @@ namespace :adventure_catalog do
         adv.destroy if adv
       end
   end
+
+  desc "Delete all adventures"
+  task :delete_all => :environment do
+    deleted = Adventure.delete_all
+    puts "*** Deleted #{deleted} adventures"
+  end
 end


### PR DESCRIPTION
Fixes #183 

Added a parsing shim to correct the module name. Additionally, I added a rake task to delete all of the existing `Adventure` rows so that you can drop and load them while developing new shims.