### PR TITLE
Fixed Typo for T3 Gold Gains.

### DIFF
--- a/app/models/character/gold_concern.rb
+++ b/app/models/character/gold_concern.rb
@@ -12,7 +12,7 @@ module Character::GoldConcern
     return    0 if level <= 1
     return   75 if level <= 4
     return  150 if level <= 10
-    return  559 if level <= 16
+    return  550 if level <= 16
     return 5500
   end
 


### PR DESCRIPTION
It will give 550 instead of 559 now. Referenced by a commenter in #207

Using a separate branch this time.