### PR TITLE
Route Change to Fix Reset Password URL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ AdventurersLeagueLog::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  Rails.application.routes.default_url_options[:host] = 'adventurersleaguelog.com'
+  Rails.application.routes.default_url_options[:host] = 'www.adventurersleaguelog.com'
 
   ActionMailer::Base.smtp_settings = {
     port: '587',


### PR DESCRIPTION
RE: #184 

When following the link in the email from sendgrid, it fails to load the app, because
it's trying to hit adventurersleaguelog.com, instead of www.adventurersleaguelog.com,
simply adding it to the address bar fixes the problem, and I believe this code change
will fix it globally.